### PR TITLE
Use correct version label for g8s-grafana

### DIFF
--- a/helm/aws-app-collection-chart/templates/g8s-grafana-unique.yaml
+++ b/helm/aws-app-collection-chart/templates/g8s-grafana-unique.yaml
@@ -5,7 +5,7 @@ metadata:
     chart-operator.giantswarm.io/force-helm-upgrade: "true"
   creationTimestamp: null
   labels:
-    app-operator.giantswarm.io/version: 0.0.0
+    app-operator.giantswarm.io/version: 1.0.0
   name: g8s-grafana-unique
   namespace: giantswarm
 spec:


### PR DESCRIPTION
This CR was updated with 0.0.0 as the version. We need to revert to 1.0.0 so CR works with app-operator 1.0.3.

See https://github.com/giantswarm/architect/pull/449