### PR TITLE
Restore cluster-operator v2.1.5

### DIFF
--- a/helm/aws-app-collection-chart/templates/cluster-operator-2.1.5.yaml
+++ b/helm/aws-app-collection-chart/templates/cluster-operator-2.1.5.yaml
@@ -5,7 +5,7 @@ metadata:
     chart-operator.giantswarm.io/force-helm-upgrade: "true"
   creationTimestamp: null
   labels:
-    app-operator.giantswarm.io/version: 1.0.0
+    app-operator.giantswarm.io/version: 0.0.0
   name: cluster-operator-2.1.5
   namespace: giantswarm
 spec:


### PR DESCRIPTION
Revert 312d31ff9b763453ff7a7180b46c9d54ada90716 for only cluster-operator 2.1.5. 

IC consult is still using 2.1.5 in their production. 
