### PR TITLE
Use latest versions of app-operator and chart-operator

### DIFF
--- a/helm/aws-app-collection-chart/templates/app-operator-unique.yaml
+++ b/helm/aws-app-collection-chart/templates/app-operator-unique.yaml
@@ -31,7 +31,7 @@ spec:
     secret:
       name: ""
       namespace: ""
-  version: 1.0.8
+  version: 1.1.8
 status:
   appVersion: ""
   release:

--- a/helm/aws-app-collection-chart/templates/chart-operator-unique.yaml
+++ b/helm/aws-app-collection-chart/templates/chart-operator-unique.yaml
@@ -33,7 +33,7 @@ spec:
     secret:
       name: ""
       namespace: ""
-  version: 0.13.2
+  version: 1.0.4
 status:
   appVersion: ""
   release:


### PR DESCRIPTION
Towards giantswarm/giantswarm#11969

Getting the app collection back in sync. Will deploy new chart-operator 1.0.4 manually first.