### PR TITLE
Update cluster-operator 2.1.5-1

### DIFF
--- a/helm/aws-app-collection-chart/templates/cluster-operator-2.1.5-1.yaml
+++ b/helm/aws-app-collection-chart/templates/cluster-operator-2.1.5-1.yaml
@@ -6,7 +6,7 @@ metadata:
   creationTimestamp: null
   labels:
     app-operator.giantswarm.io/version: 0.0.0
-  name: cluster-operator-2.1.5
+  name: cluster-operator-2.1.5-1
   namespace: giantswarm
 spec:
   catalog: control-plane-catalog
@@ -33,7 +33,7 @@ spec:
     secret:
       name: ""
       namespace: ""
-  version: 2.1.5
+  version: 2.1.5-1
 status:
   appVersion: ""
   release:


### PR DESCRIPTION
Fixing the validation issue. 
```
    reason: 'helm validation error: (unable to build kubernetes objects from release
      manifest: error validating "": error validating data: unknown object type "nil"
      in Deployment.spec.template.metadata.annotations.releasetime)'
```