### PR TITLE
Fix architect extraction in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - run:
           name: Download architect
           command: |
-            curl -fsSL https://github.com/giantswarm/architect/releases/download/v2.1.0/architect-v2.1.0-linux-amd64.tar.gz | tar -xzv --strip-components 1 '*/architect'
+            curl -fsSL https://github.com/giantswarm/architect/releases/download/v2.1.0/architect-v2.1.0-linux-amd64.tar.gz | tar -xzv --strip-components 1 --wildcards '*/architect'
             ./architect version
       - run:
           name: Deploy


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12241

See https://circleci.com/gh/giantswarm/aws-app-collection/586?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link