### PR TITLE
Bump up architect version to 2.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - run:
           name: Download architect
           command: |
-            architect_version="2.1.0"
+            architect_version="2.1.1"
             curl -fsSL https://github.com/giantswarm/architect/releases/download/v${architect_version}/architect-v${architect_version}-linux-amd64.tar.gz | tar -xzv --strip-components 1 --wildcards '*/architect'
             ./architect version
       - run:


### PR DESCRIPTION
Bump up architect version to 2.1.1 to include `visitor` installation into aws deployment. 