### PR TITLE
update circleci config for bandicoot installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - run:
           name: Download architect
           command: |
-            architect_version="2.1.1"
+            architect_version="2.1.5"
             curl -fsSL https://github.com/giantswarm/architect/releases/download/v${architect_version}/architect-v${architect_version}-linux-amd64.tar.gz | tar -xzv --strip-components 1 --wildcards '*/architect'
             ./architect version
       - run:


### PR DESCRIPTION
update architect to deploy to `bandicoot` (see https://github.com/giantswarm/architect/compare/v2.1.4...v2.1.5)
