### PR TITLE
Revert app-admission-controller to 0.10.1

### DIFF
--- a/manifests/app-admission-controller.yaml
+++ b/manifests/app-admission-controller.yaml
@@ -15,7 +15,7 @@ spec:
       - name: KONFIGURE_APP_NAME
         value: app-admission-controller
       - name: KONFIGURE_APP_VERSION
-        value: 0.11.0
+        value: 0.10.1
       - name: KONFIGURE_APP_CATALOG
         value: control-plane-catalog
       name: konfigure


### PR DESCRIPTION
Reverting due to problem in Anteater installing app with values in Happa.

See https://gigantic.slack.com/archives/C02EVLE9W/p1629307003058800