### PR TITLE
Remove capa-iam-operator from kustomization

### DIFF
--- a/flux-manifests/kustomization.yaml
+++ b/flux-manifests/kustomization.yaml
@@ -5,7 +5,6 @@ generators:
 - athena.yaml
 - aws-admission-controller.yaml
 - aws-collector.yaml
-- capa-iam-operator.yaml
 - cert-exporter.yaml
 - cert-manager-app.yaml
 - chart-operator.yaml


### PR DESCRIPTION
We also need to remove from the kustomization or it errors.


```
k -n flux-giantswarm get kustomization  collection
NAME         READY   STATUS                                                                                                                                                                                                                                                                                                                                                                                                                     AGE
collection   False   kustomize build failed: loading generator plugins: accumulation err='accumulating resources from 'capa-iam-operator.yaml': open /tmp/collection1709704345/flux-manifests/capa-iam-operator.yaml: no such file or directory': evalsymlink failure on '/tmp/collection1709704345/flux-manifests/capa-iam-operator.yaml' : lstat /tmp/collection1709704345/flux-manifests/capa-iam-operator.yaml: no such file or directory   17d
```