### PR TITLE
Manually update app-exporter to 0.17.1.

### DIFF
--- a/flux-manifests/app-exporter.yaml
+++ b/flux-manifests/app-exporter.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: app-exporter
-app_version: 0.17.0
+app_version: 0.17.1
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
Fixes an issue with scrape timeout higher than scrape interval which crashes Prometheus.