### PR TITLE
Cluster API: Bump to v1.5.4.

### DIFF
--- a/flux-manifests/cluster-api.yaml
+++ b/flux-manifests/cluster-api.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api
-app_version: 1.5.1
+app_version: 1.5.4
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
Changelog: https://github.com/giantswarm/cluster-api-app/blob/main/CHANGELOG.md
Comparison: https://github.com/giantswarm/cluster-api-app/compare/v1.5.1...v1.5.4

Towards https://github.com/giantswarm/giantswarm/issues/30063.